### PR TITLE
Fix for Rails 3.0.0 deprecation of Object#returning

### DIFF
--- a/lib/machinist/mongo_mapper.rb
+++ b/lib/machinist/mongo_mapper.rb
@@ -57,7 +57,7 @@ module Machinist
       end
 
       def make_unsaved(*args)
-        returning(Machinist.with_save_nerfed { make(*args) }) do |object|
+        Machinist.with_save_nerfed{ make(*args) }.tap do |object|
           yield object if block_given?
         end
       end

--- a/lib/machinist/mongoid.rb
+++ b/lib/machinist/mongoid.rb
@@ -58,7 +58,7 @@ module Machinist
       end
       
       def make_unsaved(*args)
-        returning(Machinist.with_save_nerfed { make(*args) }) do |object|
+        Machinist.with_save_nerfed { make(*args) }.tap do |object|
           yield object if block_given?
         end
       end


### PR DESCRIPTION
Please find a little patch to prevent Rails 3.0.0 (activesupport 3.0.0) from spitting deprecation warning about Object#returning.

Also there is a dependencies incompatibility between mongoid and mongomapper, the former (2.0.0.pre.18) require mongo '= 1.0.7' when the later require mongo '~> 1.0.8'. I get the specs pass by commenting alternatively mongoid then mongomapper dep. in the Gemfile and specs.
