### PR TITLE
Converted mongo_mapper extension as an ActiveSupport::Concern

### DIFF
--- a/lib/machinist/mongo_mapper.rb
+++ b/lib/machinist/mongo_mapper.rb
@@ -46,40 +46,54 @@ module Machinist
   end
 
   module MongoMapperExtensions
-    module Document
-      def make(*args, &block)
-        lathe = Lathe.run(Machinist::MongoMapperAdapter, self.new, *args)
-        unless Machinist.nerfed?
-          lathe.object.save!
-          lathe.object.reload
-        end
-        lathe.object(&block)
-      end
 
-      def make_unsaved(*args)
-        Machinist.with_save_nerfed{ make(*args) }.tap do |object|
-          yield object if block_given?
-        end
-      end
+    module MachinistDocument
+      extend ActiveSupport::Concern
+        
+      module ClassMethods
+        include Machinist::Blueprints::ClassMethods
 
-      def plan(*args)
-        lathe = Lathe.run(Machinist::MongoMapperAdapter, self.new, *args)
-        Machinist::MongoMapperAdapter.assigned_attributes_without_associations(lathe)
+        def make(*args, &block)
+          lathe = Lathe.run(Machinist::MongoMapperAdapter, self.new, *args)
+          unless Machinist.nerfed?
+            lathe.object.save!
+            lathe.object.reload
+          end
+          lathe.object(&block)
+        end
+
+        def make_unsaved(*args)
+          Machinist.with_save_nerfed{ make(*args) }.tap do |object|
+            yield object if block_given?
+          end
+        end
+
+        def plan(*args)
+          lathe = Lathe.run(Machinist::MongoMapperAdapter, self.new, *args)
+          Machinist::MongoMapperAdapter.assigned_attributes_without_associations(lathe)
+        end
       end
     end
 
-    module EmbeddedDocument
+    module MachinistEmbeddedDocument
+      extend ActiveSupport::Concern
 
-      def make(*args, &block)
-        lathe = Lathe.run(Machinist::MongoMapperAdapter, self.new, *args)
-        lathe.object(&block)
+      module ClassMethods
+        include Machinist::Blueprints::ClassMethods
+
+        def make(*args, &block)
+          lathe = Lathe.run(Machinist::MongoMapperAdapter, self.new, *args)
+          lathe.object(&block)
+        end
       end
     end
   end
 end
 
-MongoMapper::Document.append_extensions(Machinist::Blueprints::ClassMethods)
-MongoMapper::Document.append_extensions(Machinist::MongoMapperExtensions::Document)
+module MongoMapper::Document
+  include Machinist::MongoMapperExtensions::MachinistDocument
+end
 
-MongoMapper::EmbeddedDocument.append_extensions(Machinist::Blueprints::ClassMethods)
-MongoMapper::EmbeddedDocument.append_extensions(Machinist::MongoMapperExtensions::EmbeddedDocument)
+module MongoMapper::EmbeddedDocument
+  include Machinist::MongoMapperExtensions::MachinistEmbeddedDocument
+end

--- a/lib/machinist/mongo_mapper.rb
+++ b/lib/machinist/mongo_mapper.rb
@@ -47,7 +47,7 @@ module Machinist
 
   module MongoMapperExtensions
 
-    module MachinistDocument
+    module Document
       extend ActiveSupport::Concern
         
       module ClassMethods
@@ -75,7 +75,7 @@ module Machinist
       end
     end
 
-    module MachinistEmbeddedDocument
+    module EmbeddedDocument
       extend ActiveSupport::Concern
 
       module ClassMethods
@@ -91,9 +91,9 @@ module Machinist
 end
 
 module MongoMapper::Document
-  include Machinist::MongoMapperExtensions::MachinistDocument
+  include Machinist::MongoMapperExtensions::Document
 end
 
 module MongoMapper::EmbeddedDocument
-  include Machinist::MongoMapperExtensions::MachinistEmbeddedDocument
+  include Machinist::MongoMapperExtensions::EmbeddedDocument
 end


### PR DESCRIPTION
Stops me seeing deprecation warnings whenever I run specs or cukes.
